### PR TITLE
experiment: disable abi3 to measure perf overhead via CodSpeed

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -230,6 +230,10 @@ jobs:
     name: Verify abi3 wheel on Python ${{ matrix.python-version }}
     needs: linux
     runs-on: ubuntu-22.04
+    # Disabled on this experimental branch: with `abi3-py310` removed from
+    # `Cargo.toml`, the wheel is now `cp310-cp310` and only loads on
+    # Python 3.10. Cross-version smoke testing isn't applicable here.
+    if: false
     strategy:
       matrix:
         python-version: ['3.11', '3.12', '3.13']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ opentelemetry-jaeger = { version = "0.19", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.13", features = ["trace", "reqwest-client", "grpc-tonic"] }
 opentelemetry-prometheus = "0.13.0"
 prometheus = { version = "0.13.3" }
-pyo3 = { version = "0.22.6", features = ["macros", "chrono", "abi3-py310", "gil-refs"] }
+pyo3 = { version = "0.22.6", features = ["macros", "chrono", "gil-refs"] }
 rusqlite = { version = "0.30.0", features = ["bundled", "series"] }
 rusqlite_migration = { version = "1.1.0" }
 seahash = { version = "4.1.0" }
@@ -32,7 +32,7 @@ tracing-opentelemetry = { version = "0.20" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-pyo3 = { version = "0.22.6", features = ["macros", "chrono", "abi3-py310", "gil-refs"] }
+pyo3 = { version = "0.22.6", features = ["macros", "chrono", "gil-refs"] }
 
 [features]
 extension-module = ["pyo3/extension-module"]


### PR DESCRIPTION
## Purpose

This PR is **not for merge**. It exists to gather CodSpeed comparison data: how much does `abi3-py310` cost us in instruction count vs a non-abi3 build?

## Changes

- `Cargo.toml`: removed `"abi3-py310"` from the pyo3 features list. This switches builds back to the full Python C-API and produces version-specific wheels (e.g. `cp310-cp310-...whl`) instead of the single abi3 wheel.
- `.github/workflows/CI.yml`: disabled the `test-abi3` job with `if: false`. Cross-version smoke testing isn't applicable when the wheel is no longer abi3 — it's now Python-3.10-only.

No Rust source code changes. The pyo3 version (0.22.6) and all our existing manual `Clone` impls / `IntoPy` patterns are unchanged.

## What to look at

CodSpeed will post a comparison comment on this PR. Per-benchmark deltas vs `main`:

- `test_branch_benchmark` — high-frequency, small per-op work; should show the largest abi3 cost, if any.
- `test_flat_map_batch_benchmark` — batched ops; smaller per-op overhead, smaller delta expected.
- `test_fold_window_benchmark` — windowing has nontrivial Rust state; abi3 cost should be smallest here as the Rust work dominates.

## Decision criteria (rough)

- All deltas <2%: abi3 is essentially free for our workload. Keep abi3.
- Some deltas 2–10%: ambiguous. Read in conjunction with the wheel-matrix simplification benefit.
- Any delta >10% on a representative benchmark: reconsider keeping abi3, or look for the specific code path that's hot and optimize it.

## Next step

Whatever the data says, write an ADR (e.g. `docs/decisions/0001-abi3-wheels.md`) documenting the choice and the numbers. Then close this PR without merging — the experiment branch stays as a reference; main keeps abi3 (or gets reverted via a separate PR if the data argues otherwise).