### PR TITLE
experiment: calibrate CodSpeed by introducing a known regression

### DIFF
--- a/pytests/operators/test_branch.py
+++ b/pytests/operators/test_branch.py
@@ -74,11 +74,28 @@ def test_branch_raises_on_non_bool_key():
             run_main(flow)
 
 
+def _busy_identity(x: int) -> int:
+    """CodSpeed calibration: do pointless work per item, return value unchanged.
+
+    Each call runs ~100 Python loop iterations (~5000 bytecode-level
+    instructions). With 100,000 items per benchmark run that's ~5×10^8
+    extra instructions — well above CodSpeed's threshold and easy to spot.
+    Used to verify CodSpeed reliably flags deterministic regressions.
+    Revert before merging.
+    """
+    total = 0
+    for i in range(100):
+        total += i
+    return x
+
+
 def build_branch_dataflow(
     inp: TestingSource, out_evens: List, out_odds: List
 ) -> Dataflow:
     flow = Dataflow("branch")
     s = op.input("inp", flow, inp)
+    # CALIBRATION: redundant identity map that burns CPU per item.
+    s = op.map("calibration_slowdown", s, _busy_identity)
     branch_out = op.branch("evens_and_odds", s, lambda x: x % 2 == 0)
     op.output("out_evens", branch_out.trues, TestingSink(out_evens))
     op.output("out_odds", branch_out.falses, TestingSink(out_odds))


### PR DESCRIPTION
## Purpose

This PR is **not for merge**. It introduces a deterministic, isolated slowdown in exactly one benchmark (`test_branch_benchmark`) so we can verify CodSpeed reliably flags regressions.

If CodSpeed catches this regression, we trust the "no change" result we got on the abi3-disable PR (#4). If it doesn't, we know the bench suite is too coarse to detect what we care about.

## Change

`pytests/operators/test_branch.py` — `build_branch_dataflow` now includes an extra `op.map("calibration_slowdown", s, _busy_identity)` step. `_busy_identity` runs ~100 Python loop iterations per item (returns the value unchanged so test assertions still pass).

For the 100,000-item benchmark that's ~5×10^8 extra instructions per run — well above CodSpeed's typical ~1% threshold.

## Expected outcome

- `test_branch_benchmark[run_main]`: regression flagged ⚠️
- `test_branch_benchmark[cluster_main-1thread]`: regression flagged ⚠️
- `test_flat_map_batch_benchmark`: untouched ✓
- `test_fold_window_benchmark`: untouched ✓

## How to read the result

1. **Both branch benchmarks regress, others untouched** → CodSpeed works correctly, deltas are isolated to the modified test path. The abi3 "no change" result is trustworthy. → Write the ADR.
2. **All four regress** → noise floor higher than expected; investigate before drawing conclusions.
3. **Nothing regresses** → suite isn't sensitive enough; reconsider what we can detect.

Close without merging once the result is in.