### PR TITLE
docs: sync references to fork state and rewrite release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,9 +67,8 @@ Important Labels:
 
 ### Fork and Clone
 
-[Fork the canonical Bytewax
-repository](https://github.com/bytewax/bytewax/fork). Then clone your
-fork to your local machine.
+[Fork this repository](https://github.com/ekiourk/bytewax/fork). Then
+clone your fork to your local machine.
 
 ### Setup Development Environment
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Bytewax: Python Stateful Stream Processing Framework
 
+> Forked from [bytewax/bytewax](https://github.com/bytewax/bytewax).
+> This fork tracks ongoing maintenance (Python 3.13, abi3 wheels,
+> dependency modernization). Not affiliated with Bytewax the company.
+> Not currently published to PyPI.
+
 <div align='center'>
  <a href="https://bytewax.io/">
 <picture>
@@ -11,10 +16,8 @@
 </div>
 
 <p align='center'>
-<a href="https://github.com/bytewax/bytewax/actions"><img src="https://github.com/bytewax/bytewax/workflows/CI/badge.svg"></a>
-<a href="https://pypi.org/project/bytewax/"><img src="https://img.shields.io/pypi/v/bytewax.svg"></a>
-<a href="https://docs.bytewax.io/stable/guide/index.html"><img src="https://img.shields.io/badge/user-guide-brightgreen"></a>
-<a href="https://github.com/bytewax/bytewax/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>
+<a href="https://github.com/ekiourk/bytewax/actions"><img src="https://github.com/ekiourk/bytewax/workflows/CI/badge.svg"></a>
+<a href="https://github.com/ekiourk/bytewax/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>
 <a href="https://codspeed.io/ekiourk/bytewax?utm_source=badge"><img src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" alt="CodSpeed"/></a>
 </p>
 
@@ -194,11 +197,11 @@ Our commerically licensed Platform
 
 Join us on [Slack](https://join.slack.com/t/bytewaxcommunity/shared_invite/zt-vkos2f6r-_SeT9pF2~n9ArOaeI3ND2w) for support and discussion.
 
-Open issues on [GitHub Issues](https://github.com/bytewax/bytewax/issues) for bug reports and feature requests. (For general help, use Slack.)
+Open issues on [GitHub Issues](https://github.com/ekiourk/bytewax/issues) for bug reports and feature requests against this fork. (For general help, use Slack.)
 
 **Contributions Welcome:**
 - Check out the [Contribution Guide](https://docs.bytewax.io/stable/guide/contributing/contributing.html) to learn how to get started.
-- We follow a [Code of Conduct](https://github.com/bytewax/bytewax/blob/main/CODE_OF_CONDUCT.md).
+- We follow a [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ---
 

--- a/docs/guide/contributing/local-development.md
+++ b/docs/guide/contributing/local-development.md
@@ -24,7 +24,7 @@ installation
 instructions](https://github.com/casey/just?tab=readme-ov-file#installation).
 There's probably a package for your OS already.
 
-### Install `pyenv` and Python 3.12
+### Install `pyenv` and Python 3.13
 
 We want Bytewax to run under many different versions of the Python
 interpreter, so we need a quick way to create virtualenvs in different

--- a/docs/guide/contributing/release.md
+++ b/docs/guide/contributing/release.md
@@ -1,9 +1,11 @@
 # Library Release Checklist
 
-Here is a process checklist for Bytewax employees to release a new
-version of the Python library. Contributors do not need to follow the
-steps within and instead should follow the instructions in
-<project:#contributing>.
+Release process for this fork. The fork is **not currently published
+to PyPI**; releases produce GitHub Releases with pre-built abi3 wheels
+attached as downloadable assets. PyPI publishing is on the roadmap (see
+`docs/decisions/0001-abi3-wheels.md` for the wheel-format ADR; PyPI
+Trusted Publishing will be added as its own focused workflow when we're
+ready).
 
 ## 1. One Final PR
 
@@ -31,7 +33,7 @@ Make a PR which commits the following:
 3. Labels the latest changelog entries with the version number
 
    Look in `CHANGELOG.md` for the latest batch of hand-written
-   changelog notes and add a new headings with the version number.
+   changelog notes and add a new heading with the version number.
 
    ```{code-block} diff
    :caption: CHANGELOG.md
@@ -47,114 +49,94 @@ Make a PR which commits the following:
       automatically.
    ```
 
-4. Write migration guide entry
+4. (Optional) Write migration guide entry
 
-   Add a section to `docs/user_guide/reference/migration.md` like
-
-   ````{code-block} markdown
-   :caption: docs/user_guide/reference/migration.md
-   ## From v1.2.2 to v1.2.3
-
-   ### Breaking change to `Cow` API
-
-   The `Cow` API is now named `Bear`.
-
-   If you had code that looked like this
-
-   ```python
-   from bytewax.dataflow import Cow
-
-   flow = Cow()
-   ```
-
-   It now is should be written as
-
-   ```{testcode}
-   from bytewax.dataflow import Bear
-
-   flow = Bear("flow_id")
-   ```
-   ````
-
-   Then add sub-sections for each of the breaking changes with before
-   and after example code.
-
-   You should change any `{testcode}` blocks in the previous versions
-   into `python` now that they are no valid code with this new version
-   of Bytewax.
+   For breaking changes only. Add a section to
+   `docs/guide/reference/migration.md` with before/after example code.
+   See existing entries for the format.
 
 Then check before merging:
 
 1. Confirm CI tests pass.
+2. Confirm `repo-checks` (the lint/doctest job) passed.
 
-2. Confirm that the documentation for this build renders correctly: go
-    to the list of actions at the bottom of the PR, and click on the
-    `Details` link next to the last `docs/readthedocs.org:bytewax`
-    entry.
+Approve and merge the PR.
 
-Approve and merge that PR.
+## 2. Push the release tag
 
-Check that the CI run completed for the just updated `main` branch on
-[our CI actions
-page](https://github.com/bytewax/bytewax/actions/workflows/CI.yml)
-after merging the PR.
+The CI workflow watches for tag pushes. When a tag is pushed, the
+`publish-release` job (in `.github/workflows/CI.yml`) downloads the
+built wheels and attaches them to a new GitHub Release.
 
-## 3. Create Release on GitHub
+**Tag conventions:**
 
-Go to the [create a new GitHub release page for our
-repo](https://github.com/bytewax/bytewax/releases).
+- `vX.Y.Z` (e.g. `v1.2.3`) → published as a **full release**
+- Anything else (e.g. `dev-2026-05-03`, `rc-1`, `alpha-2`) → published
+  as a **prerelease**
 
-1. Choose a tag and enter a tag with the new version number `v1.2.3`.
+Push the tag from your local clone after the release PR has merged:
 
-2. Click "Auto-generate release notes".
+```console
+$ git checkout main
+$ git pull origin main
+$ git tag v1.2.3
+$ git push origin v1.2.3
+```
 
-   This will pre-populate the GitHub release notes with a list of
-   changes via PRs.
+CI will then:
 
-3. Copy and paste any hand-written notes from the section of
-   [`CHANGELOG.md`](https://raw.githubusercontent.com/bytewax/bytewax/main/CHANGELOG.md)
-   with this version into a new section of the GitHub release
-   description at the top.
+1. Build all wheels (one abi3 wheel per platform/arch — 6 total: 3
+   Linux + 2 macOS + 1 Windows).
+2. Run the test suite on each.
+3. Run the abi3 cross-version smoke tests.
+4. Create a GitHub Release named after the tag.
+5. Attach all 6 wheels to the release as downloadable assets.
+
+Total runtime is ~15 minutes for the full matrix.
+
+## 3. Verify the release
+
+After CI completes:
+
+1. Visit <https://github.com/ekiourk/bytewax/releases>.
+2. Confirm the new release exists with all 6 wheels attached.
+3. GitHub will have auto-generated release notes from the merged PRs.
+   Edit the release description and prepend the hand-written
+   `CHANGELOG.md` notes for this version.
 
    ```{code-block} diff
    :caption: GitHub Release Notes Form
    +## Overview
-   +* Paste in the stuff in `CHANGELOG.md` here.
+   +* Paste in the stuff from `CHANGELOG.md` here.
    +
     ## What's Changed
     * List of PRs that were merged, but sometimes the names aren't helpful.
    ```
 
-4. Wait until the CI run above for the `main` branch completes. The
-   next CD step needs the wheel packages that are built during CI. It
-   looks like this usually takes ~20 min.
+4. Hit "Update release."
 
-5. *Press "Publish release"!*
+Users can then install a specific version directly from the release
+URL:
 
-   This should create a tag in our repo named `v1.2.3` and CD will
-   kick off, pushing the final package to PyPI.
+```console
+$ pip install https://github.com/ekiourk/bytewax/releases/download/v1.2.3/bytewax-1.2.3-cp310-abi3-manylinux_2_28_x86_64.whl
+```
 
-   Check that the CD run completed on [our CD actions
-   page](https://github.com/bytewax/bytewax/actions/workflows/CD.yml).
+(Adjust the wheel filename to match the user's platform.)
 
-## 3. Double check PyPI
+## 4. Future: PyPI publishing
 
-Double check our [Bytewax PyPI
-page](https://pypi.org/project/bytewax/) to make sure that the new
-version of the package is there.
+When PyPI publishing is set up, this section will document the
+GitHub-native flow via [Trusted Publishing](https://docs.pypi.org/trusted-publishers/):
 
-## 4. Double check ReadTheDocs
+- A separate workflow (`.github/workflows/publish-pypi.yml`) will
+  trigger on `release.published` events.
+- It uses `pypa/gh-action-pypi-publish` with OIDC — no PyPI tokens
+  stored in GitHub.
+- The PyPI project name will likely **not** be `bytewax` (that's
+  owned by the original Bytewax company). A fork-specific name like
+  `bytewax-community` or similar will be chosen at the time of
+  publication.
 
-We host our docs at <https://docs.bytewax.io> which are hosted by
-[Read The Docs](https://docs.readthedocs.io/en/stable/index.html). The
-RTD project should automatically detect that a new tag was created and
-build the documentation from that tag, through the [automation rules
-setup here](https://readthedocs.org/dashboard/bytewax/rules/).
-
-Double check that the build for this new version completed at the
-[builds page for our
-project](https://readthedocs.org/projects/bytewax/builds/). Then go to
-our [live production docs](https://docs.bytewax.io) and ensure that
-the new release docs are being shown for the `stable` version.
-
-I think we're done! Update this if we're not!
+Until then, GitHub Releases are the canonical distribution channel for
+this fork.

--- a/docs/guide/deployment/container.md
+++ b/docs/guide/deployment/container.md
@@ -43,7 +43,7 @@ Create a `Dockerfile` with the following content:
 :substitutions:
 
 # Start from a debian slim with python support
-FROM python:3.11-slim-bullseye
+FROM python:3.12-slim-bookworm
 # Set up a workdir where we can put our dataflow
 WORKDIR /bytewax
 # Install bytewax and the dependencies you need here
@@ -413,6 +413,6 @@ BYTEWAX_PYTHON_FILE_PATH=examples.pagerank:flow
 
 ## Bytewax Container Images and Security
 
-Our Images are based on `python:$PYTHON_VERSION-slim-bullseye` images
+Our Images are based on `python:$PYTHON_VERSION-slim-bookworm` images
 which have a small attack surface (less than 50MB) and a very good
 scan report with zero CVE at the time of this writing.


### PR DESCRIPTION
Companion to #6 (ADR 0001). Audits and corrects user-facing/contributor-facing docs that still describe upstream state.

## Changes

### `README.md`
- Added a small "Forked from..." attribution line under the title. Explicit about: this is a fork; not affiliated with Bytewax the company; not currently on PyPI.
- Updated CI badge to point at this fork's CI status (was showing upstream's status).
- Removed PyPI version badge (was linking to upstream's PyPI page; misleading until we publish under our own name).
- Removed user-guide badge (linked to `docs.bytewax.io`, which is upstream's RTD; this fork doesn't have RTD set up).
- Updated LICENSE link, "Open Issues" link, and Code of Conduct link to point at this fork.
- **Did not** change the project description, marketing copy, or upstream-hosted logo/animation assets — those remain accurate and avoid divergence from upstream copy.

### `CONTRIBUTING.md`
- Fixed the "Fork the repository" link (was pointing at `bytewax/bytewax/fork`).

### `docs/guide/contributing/local-development.md`
- Heading "Install pyenv and Python 3.12" → "...Python 3.13". The body already said 3.13; this fixes the inconsistency.

### `docs/guide/deployment/container.md`
- Example `Dockerfile` base image: `python:3.11-slim-bullseye` → `python:3.12-slim-bookworm`, matching the actual `Dockerfile.release` we updated in PR #1.
- Prose reference to `bullseye` images → `bookworm`.

### `docs/guide/contributing/release.md`
- Rewritten end-to-end. The previous version described a release pipeline (S3 staging, automatic PyPI push, ReadTheDocs auto-build) that no longer exists in this fork — that pipeline lived in `CD.yml`, which was deleted in PR #3.
- New version describes the actual flow: bump version → tag push → CI builds and attaches wheels to a GitHub Release.
- Added a "Future: PyPI publishing" section as a placeholder for when Trusted Publishing is set up.

## Out of scope (deliberately)

- **Migration guide entry** for the 3.8/3.9 drop and abi3 wheel format. The fork hasn't published a versioned release yet; users can't have migrated *between* releases. CHANGELOG.md already documents the breaking changes. Add a migration entry when we cut the first fork release.
- **Project rename / PyPI naming**. Deferred until we're actually publishing. ADR 0001 mentions this; release.md notes a fork-specific PyPI name will be chosen at publication time.

## Validation
- `just test-doc` passes (224 doctests, 0 failures).
- Verified all changed link targets exist where they claim to.