### PR TITLE
ci: run kafka integration tests via testcontainers, fix broken DockerException import

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,6 +103,14 @@ jobs:
           # (e.g. PyType_GetModuleName via `PyType::module()`).
           args: --release --out dist/ -i 3.10
           sccache: true
+      - name: Pre-pull Kafka image
+        # The kafka_server fixture starts a testcontainers Kafka on
+        # demand. Pre-pulling makes the cost observable (separate CI
+        # step) instead of hidden inside the first test that uses it,
+        # and means the per-test pytest-timeout doesn't need to budget
+        # for a ~30-60s image pull.
+        if: ${{ matrix.target == 'x86_64' }}
+        run: docker pull confluentinc/cp-kafka:7.6.0
       - name: Run Python tests
         # Only run tests for the host architecture, as aarch64 and
         # armv7 are cross-compiled on Ubuntu runners.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,13 @@ exclude_lines = [
 module = "confluent_kafka.*"
 ignore_missing_imports = true
 
+# `docker` (the docker-py SDK, used via testcontainers) doesn't ship
+# type stubs. Used only in `pytests/conftest.py` for catching
+# `DockerException`.
+[[tool.mypy.overrides]]
+module = "docker.*"
+ignore_missing_imports = true
+
 # TODO: pre-existing type debt — `KafkaSourceMessage.topic` is `Optional[str]`
 # but `confluent-kafka>=2.14`'s stubs require non-None for `SerializationContext`.
 # Tighten the connector types (likely change `topic` to `str` and validate at

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -18,11 +18,13 @@ from pytest import fixture
 def kafka_server():
     """Provide a Kafka broker URL.
 
-    If `TEST_KAFKA_BROKER` is set to a non-empty value, use it. Otherwise
-    fall back to spinning up a local container via `testcontainers` for
-    local development. In CI we always require an explicit broker — the
-    container fallback pulls a ~600MB image and frequently hangs on
-    runners — so without one, the tests skip.
+    Resolution order:
+    1. If `TEST_KAFKA_BROKER` is set to a non-empty value, use it as-is.
+    2. Otherwise spin up a Kafka container via `testcontainers` (works
+       both locally and on CI runners that have Docker, e.g. linux GHA).
+    3. If Docker isn't available (e.g. on macOS/Windows GHA runners
+       without Docker, or in environments without the daemon running),
+       skip with a clear reason.
 
     """
     broker = os.environ.get("TEST_KAFKA_BROKER", "").strip()
@@ -30,18 +32,24 @@ def kafka_server():
         yield broker
         return
 
-    if os.environ.get("CI") == "true":
-        pytest.skip("TEST_KAFKA_BROKER not set in CI; skipping Kafka tests")
-
-    # Local dev: try testcontainers.
+    # Deferred imports so the suite still runs without `testcontainers`
+    # or the underlying `docker` library.
     try:
-        from testcontainers.core.exceptions import DockerException  # noqa: PLC0415
+        from docker.errors import DockerException  # noqa: PLC0415
         from testcontainers.kafka import KafkaContainer  # noqa: PLC0415
     except ImportError:
-        pytest.skip("`testcontainers` not installed; skip Kafka tests")
+        pytest.skip("`testcontainers` or `docker` not installed; skip Kafka tests")
 
     try:
-        with KafkaContainer("confluentinc/cp-kafka:7.6.0") as kafka:
+        # Disable auto-topic-creation on the broker: tests that need
+        # topics create them explicitly via AdminClient (see `tmp_topic`),
+        # and `test_input_raises_on_topic_not_exist` relies on the
+        # broker actually rejecting a missing-topic read instead of
+        # silently materializing the topic.
+        kafka_container = KafkaContainer("confluentinc/cp-kafka:7.6.0").with_env(
+            "KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false"
+        )
+        with kafka_container as kafka:
             yield kafka.get_bootstrap_server()
     except DockerException as e:
         pytest.skip(f"Docker not available: {e}")

--- a/pytests/connectors/test_kafka.py
+++ b/pytests/connectors/test_kafka.py
@@ -4,6 +4,7 @@ from concurrent.futures import wait
 from typing import Tuple
 
 import bytewax.operators as op
+import pytest
 from bytewax.connectors.kafka import (
     KafkaSink,
     KafkaSinkMessage,
@@ -22,6 +23,13 @@ from confluent_kafka import (
 )
 from confluent_kafka.admin import AdminClient, NewTopic
 from pytest import fixture, raises
+
+# These tests rely on the `kafka_server` fixture which spins up a
+# testcontainers Kafka instance on first use. The image pull + container
+# startup + readiness can take ~60-90s on a cold machine; CI pre-pulls
+# the image, but bump the per-test timeout anyway so the first kafka
+# test in a fresh session has comfortable headroom.
+pytestmark = pytest.mark.timeout(180)
 
 
 @fixture


### PR DESCRIPTION
Second step of the test-suite improvement plan. Closes the kafka coverage gap that was hidden behind a broken import + a too-conservative CI skip.

## What was actually broken

While debugging this it turned out the kafka tests had been silently skipping with the **wrong reason** even when Docker was available. The conftest tried to import `DockerException` from `testcontainers.core.exceptions`, but `testcontainers 4.x` removed that name (it was in 3.x). The `ImportError` triggered the \"`testcontainers` not installed\" skip — except testcontainers *was* installed, just restructured. Running locally on a workstation with Docker, the tests have been unreachable since the dependency bump.

So even before discussing CI, the kafka test suite has been completely dark for a while. This fixes that.

## Changes

### `pytests/conftest.py`
- Replaced the broken `from testcontainers.core.exceptions import DockerException` with `from docker.errors import DockerException`. The latter is the canonical exception raised when Docker isn't reachable, regardless of testcontainers version.
- Removed the `if os.environ.get(\"CI\") == \"true\"` skip we added as a band-aid earlier. With the real fix in place, kafka tests can run wherever Docker is available — including linux GHA runners. The fallback skip path on `DockerException` covers macOS/Windows runners that lack Docker.
- Disabled `KAFKA_AUTO_CREATE_TOPICS_ENABLE` on the testcontainers Kafka. Without this, `test_input_raises_on_topic_not_exist` was failing because reading from a missing topic silently materialized it — the broker default in `confluentinc/cp-kafka:7.6.0` is auto-create-on. Tests that need topics create them explicitly via `AdminClient` (see `tmp_topic` fixture), so disabling auto-create matches the test suite's intent.

### `pytests/connectors/test_kafka.py`
- Added `pytestmark = pytest.mark.timeout(180)`. The session-scoped `kafka_server` fixture takes ~60-90s to set up on a cold machine (image pull + container startup + Kafka readiness). The global 60s pytest timeout would kill the first kafka test in a session even when everything is working. 180s gives comfortable headroom; subsequent tests reuse the broker and are fast (each test is ~1s).

### `.github/workflows/CI.yml`
- New \"Pre-pull Kafka image\" step in the linux x86_64 job. Moves the ~30-60s image pull out of the test fixture and into a separate, observable CI step. Means the per-test timeout doesn't need to budget for the pull.

### `pyproject.toml`
- Added a mypy override for `docker.*` (the docker-py SDK pulled in transitively by testcontainers). It doesn't ship type stubs, and we now import `DockerException` from it.

## Verification

Local results (Docker available):

```
$ pytest pytests/connectors/test_kafka.py -v
... 6 passed in 8.74s
```

Coverage on `pysrc/bytewax/connectors/kafka/__init__.py`: **41% → 91%** (172 statements; 13 missed). Overall project Python coverage: **76% → 80%**.

Where the remaining 9% on `kafka/__init__.py` lives: a few error paths (offset assignments, malformed config), and parts of the `KafkaSink` close logic. Reachable but not exercised by the existing 6 tests.

`kafka/operators.py` and `kafka/serde.py` (the schema-registry and Avro paths) are now visible in the coverage report at 0% — they had been entirely invisible before because nothing imported them in test paths. Real coverage on those modules is a separate follow-up; they need schema-registry-aware integration tests, ideally pointing at a `confluentinc/cp-schema-registry` testcontainer.

## What this completes

This was the second of the two-PR Tier 1 plan from the test-coverage analysis:
- ✅ PR #8 — coverage tooling, timeouts, Rust toolchain bump
- ✅ This PR — kafka tests live in CI

Next planned: wire up Codecov/Coveralls so PRs see coverage deltas as comments (~30 min, queued separately so this PR has a clean narrative).