### PR TITLE
ci: upload coverage to Codecov for PR-level coverage deltas

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -133,6 +133,16 @@ jobs:
         with:
           name: coverage-linux-x86_64
           path: coverage.xml
+      - name: Upload coverage to Codecov
+        if: ${{ matrix.target == 'x86_64' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          # Don't fail CI if the upload itself fails (e.g., transient
+          # Codecov outage). The coverage data is still preserved as a
+          # workflow artifact above.
+          fail_ci_if_error: false
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 <a href="https://github.com/ekiourk/bytewax/actions"><img src="https://github.com/ekiourk/bytewax/workflows/CI/badge.svg"></a>
 <a href="https://github.com/ekiourk/bytewax/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>
 <a href="https://codspeed.io/ekiourk/bytewax?utm_source=badge"><img src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" alt="CodSpeed"/></a>
+<a href="https://codecov.io/gh/ekiourk/bytewax"><img src="https://codecov.io/gh/ekiourk/bytewax/branch/main/graph/badge.svg" alt="Codecov"/></a>
 </p>
 
 


### PR DESCRIPTION
Wires Codecov into the CI pipeline. Every PR now gets an auto-comment with coverage delta vs main, per-file changes, and patch coverage (% of new lines tested).

## Changes

### `.github/workflows/CI.yml`
- New step in the linux x86_64 test job: `codecov/codecov-action@v5` uploads `coverage.xml` to Codecov.
- Uses the `CODECOV_TOKEN` secret (configured in repo settings).
- `fail_ci_if_error: false` — a Codecov outage shouldn't block PRs from merging. The coverage data is still preserved as a workflow artifact regardless.

### `README.md`
- Added Codecov badge next to the existing CodSpeed badge.

## What you'll see after merge

After this lands and CI runs against `main` once, every subsequent PR will get a Codecov comment showing:
- Total coverage delta vs the merge base (e.g. \"+0.4%\" or \"−1.2%\")
- Per-file coverage changes for files the PR touched
- Patch coverage (the % of *new* lines that have test coverage — the most useful number for catching tests-not-keeping-up-with-code)

The first comment after merge sets the baseline; subsequent PRs see deltas against that.

## What's still deferred (per the test-coverage analysis)

- **No `codecov.yml`** in this PR. Codecov's defaults are sensible for a first integration — we'll see what the comments look like, then tighten thresholds (e.g., \"PR must cover ≥70% of new lines\" or \"don't drop project coverage by >1%\") in a follow-up if needed.
- **No fail-on-coverage-drop check yet.** Same reason: visibility first, gate later.

## What this completes

End of the planned coverage-visibility track:
- ✅ PR #8 — coverage tooling locally + xml in CI artifacts
- ✅ PR #10 — kafka tests live in CI (76% → 80% project coverage)
- ✅ This PR — PR-level coverage comments on every change