### PR TITLE
test: cover plantuml renderer and CLI dispatch in visualize.py (56% → 98%)

### DIFF
--- a/pytests/test_visualize.py
+++ b/pytests/test_visualize.py
@@ -1,10 +1,18 @@
 import json
 import textwrap
+from unittest.mock import patch
 
 import bytewax.operators as op
+import pytest
 from bytewax.dataflow import Dataflow
 from bytewax.testing import TestingSink, TestingSource
-from bytewax.visualize import to_json, to_mermaid
+from bytewax.visualize import (
+    _parse_args,
+    _visualize_main,
+    to_json,
+    to_mermaid,
+    to_plantuml,
+)
 
 
 def test_to_json_linear():
@@ -430,3 +438,123 @@ def test_to_mermaid_multistream_inp():
         test_df.merge -- "down → up" --> test_df.out
         end"""
     )
+
+
+def test_to_plantuml_linear():
+    flow = Dataflow("test_df")
+    s = op.input("inp", flow, TestingSource([1, 2, 3]))
+    s = op.map("add_one", s, lambda x: x + 1)
+    op.output("out", s, TestingSink([]))
+
+    assert to_plantuml(flow) == textwrap.dedent(
+        """\
+        @startuml
+        component test_df.inp [
+            test_df.inp (input)
+        ]
+        component test_df.inp {
+            portout test_df.inp.down
+        }
+        component test_df.add_one [
+            test_df.add_one (map)
+        ]
+        component test_df.add_one {
+            portin test_df.add_one.up
+            portout test_df.add_one.down
+            test_df.inp.down --> test_df.add_one.up : test_df.inp.down
+        }
+        component test_df.out [
+            test_df.out (output)
+        ]
+        component test_df.out {
+            portin test_df.out.up
+            test_df.add_one.down --> test_df.out.up : test_df.add_one.flat_map_batch.down
+        }
+        @enduml"""
+    )
+
+
+def test_to_plantuml_recursive_shows_substeps():
+    flow = Dataflow("test_df")
+    s = op.input("inp", flow, TestingSource([1, 2, 3]))
+    s = op.map("add_one", s, lambda x: x + 1)
+    op.output("out", s, TestingSink([]))
+
+    out = to_plantuml(flow, recursive=True)
+    # The non-recursive variant doesn't include flat_map_batch substeps.
+    assert "test_df.add_one.flat_map_batch (flat_map_batch)" in out
+    # The closing connection inside the wrapping component should fire
+    # (this is the recursive-only branch in `_to_plantuml_step`).
+    assert "test_df.add_one.flat_map_batch.down --> test_df.add_one.down" in out
+
+
+def test_to_plantuml_nonlinear():
+    """A branching dataflow exercises multi-output ports."""
+    flow = Dataflow("test_df")
+    s = op.input("inp", flow, TestingSource([1, 2, 3]))
+    b = op.branch("br", s, lambda x: x % 2 == 0)
+    op.output("out_evens", b.trues, TestingSink([]))
+    op.output("out_odds", b.falses, TestingSink([]))
+
+    out = to_plantuml(flow)
+    # Both branches should appear as separate output ports of the
+    # branch step, and connect to the respective sink.
+    assert "portout test_df.br.trues" in out
+    assert "portout test_df.br.falses" in out
+    assert "test_df.br.trues --> test_df.out_evens.up" in out
+    assert "test_df.br.falses --> test_df.out_odds.up" in out
+
+
+@pytest.fixture
+def _tiny_flow():
+    flow = Dataflow("cli_test")
+    s = op.input("inp", flow, TestingSource([1]))
+    op.output("out", s, TestingSink([]))
+    return flow
+
+
+@pytest.mark.parametrize("output_format", ["json", "mermaid", "plantuml"])
+def test_visualize_main_dispatches_to_each_format(_tiny_flow, output_format, capsys):
+    """`_visualize_main` should call the right renderer for each format
+    and print its output to stdout."""
+    with patch("bytewax.visualize._locate_dataflow", return_value=_tiny_flow):
+        _visualize_main("module:flow", output_format, recursive=False)
+
+    stdout = capsys.readouterr().out
+
+    # Each format has a distinct, unmistakable preamble we can match
+    # without snapshotting the whole output (which is already covered
+    # by the per-format tests above).
+    if output_format == "json":
+        assert '"typ": "RenderedDataflow"' in stdout
+    elif output_format == "mermaid":
+        assert "flowchart TD" in stdout
+    elif output_format == "plantuml":
+        assert "@startuml" in stdout
+
+
+def test_visualize_main_unknown_format_raises(_tiny_flow):
+    with patch("bytewax.visualize._locate_dataflow", return_value=_tiny_flow):
+        with pytest.raises(ValueError, match="unknown visualization type"):
+            _visualize_main("module:flow", "graphviz", recursive=False)  # type: ignore[arg-type]
+
+
+def test_parse_args_defaults():
+    with patch("sys.argv", ["bytewax-visualize", "myflow:flow"]):
+        ns = _parse_args()
+    assert ns.import_str == "myflow:flow"
+    assert ns.output_format == "mermaid"
+    assert ns.recursive is False
+
+
+@pytest.mark.parametrize("fmt", ["json", "mermaid", "plantuml"])
+def test_parse_args_format_selection(fmt):
+    with patch("sys.argv", ["bytewax-visualize", "myflow:flow", "-o", fmt]):
+        ns = _parse_args()
+    assert ns.output_format == fmt
+
+
+def test_parse_args_recursive_flag():
+    with patch("sys.argv", ["bytewax-visualize", "myflow:flow", "--recursive"]):
+        ns = _parse_args()
+    assert ns.recursive is True


### PR DESCRIPTION
First Tier 2 coverage PR. Closes one of the three obvious gaps from the test-suite analysis.

## What was untested

`visualize.py` was at 56% before this PR. The gaps fell in two clusters:

1. **PlantUML rendering** (`to_plantuml`, `_to_plantuml_step`, lines 216–278) — the `to_mermaid` and `to_json` renderers had snapshot tests; PlantUML had none, even though the function ships as a documented public API.
2. **CLI dispatch** (`_parse_args`, `_visualize_main`, lines 351–402) — `python -m bytewax.visualize <flow>` is the documented entry point, completely untested.

## Tests added (12 new cases, all in `pytests/test_visualize.py`)

### PlantUML renderer
- `test_to_plantuml_linear` — snapshot of a 3-step linear pipeline. Same shape as the existing `test_to_mermaid_linear`.
- `test_to_plantuml_recursive_shows_substeps` — same flow with `recursive=True`. Verifies the recursive-only branch in `_to_plantuml_step` (lines 236–246) actually emits the inner-step component and the closing edge from substep output back to wrapping output port.
- `test_to_plantuml_nonlinear` — branching dataflow. Verifies multi-output ports (`portout`) and that branches connect to their respective sinks.

### CLI dispatch
- `test_visualize_main_dispatches_to_each_format` — parametrized over `json`/`mermaid`/`plantuml`. Mocks `_locate_dataflow` to return a tiny flow, captures stdout via the `capsys` fixture, asserts the expected preamble is present (`"flowchart TD"` for mermaid, `"@startuml"` for plantuml, `'"typ": "RenderedDataflow"'` for json).
- `test_visualize_main_unknown_format_raises` — covers the `else: raise ValueError` branch (line 399).
- `test_parse_args_defaults` — patches `sys.argv` and verifies the defaults (mermaid, recursive=False).
- `test_parse_args_format_selection` — parametrized over `-o json/mermaid/plantuml`.
- `test_parse_args_recursive_flag` — `--recursive` toggles the namespace field.

## Coverage delta

`pysrc/bytewax/visualize.py`: **56% → 98%** (3 lines uncovered — all JSON encoder fallback paths that need contrived inputs to trigger; diminishing returns).

Project total: **80% → 83%**.

## Test count

`pytests/test_visualize.py`: 6 → 18 tests.
Whole suite: 202 → 214.

## Local validation

- `pytest pytests/test_visualize.py` → 18 passed
- `just test-py` → 214 passed, 6 skipped (unchanged skip count)
- `just lint` → exit 0

## What this exemplifies for future Tier 2 PRs

This PR is intentionally narrow. The next two Tier 2 candidates from the analysis are:

1. **`run.py`** (currently 48%) — CLI argument parsing and dataflow-locator. Similar mock-based pattern to the CLI tests added here.
2. **`operators.rs`** (currently 0% for direct Rust unit tests) — the biggest Rust untested surface. Will need a different approach (Rust-side test fixtures rather than Python tests through pyo3).

Both will be separate PRs in this branch series.