### PR TITLE
fix: track coverage by package name so the installed wheel is measured in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,29 @@ addopts = "-v"
 timeout = 60
 
 [tool.coverage.run]
-source = ["pysrc/bytewax"]
+# Track by package name rather than by source directory: locally we use
+# `maturin develop` (editable install, files at `pysrc/bytewax/`) but
+# in CI we install the built wheel which lands in
+# `venv/lib/.../site-packages/bytewax/`. `source_pkgs` measures the
+# package wherever it was imported from; the `[tool.coverage.paths]`
+# block below canonicalizes the two locations to the same repo path.
+source_pkgs = ["bytewax"]
 branch = true
+# Record paths relative to the repo root rather than absolute, so the
+# generated coverage.xml has paths Codecov can match against the repo
+# tree.
+relative_files = true
 # `_bytewax` is the Rust extension; coverage doesn't apply.
 omit = ["pysrc/bytewax/_bytewax.pyi"]
+
+[tool.coverage.paths]
+# Collapse the editable-install path and the wheel-install path to
+# the canonical source path.
+source = [
+    "pysrc/bytewax",
+    "*/lib/python*/site-packages/bytewax",
+    "*/site-packages/bytewax",
+]
 
 [tool.coverage.report]
 # Show lines not exercised by any test.


### PR DESCRIPTION
Codecov has been reporting 0% coverage on \`main\` because of a path mismatch. This fixes the coverage config to match the way the project is actually installed in CI.

## Root cause

The local dev workflow (\`maturin develop\`) installs bytewax in **editable mode** — Python imports run against \`pysrc/bytewax/\` directly. Coverage with \`source = [\"pysrc/bytewax\"]\` correctly counts those file executions.

The CI workflow builds a **wheel** and runs \`uv pip install\` to put it in the venv. Imports then run against \`venv/lib/python3.10/site-packages/bytewax/\` — a *copy* of the source files, not the source itself. The \`source = [\"pysrc/bytewax\"]\` filter excludes those paths, so coverage records nothing → 0%.

This was invisible until Codecov was wired up, because PR #8's CI step did emit a \`coverage.xml\` artifact, but nobody was reading it.

## Fix

\`pyproject.toml\` \`[tool.coverage.run]\`:
- \`source = [\"pysrc/bytewax\"]\` → \`source_pkgs = [\"bytewax\"]\`. Coverage now tracks the bytewax *package* wherever it's imported from, not files in a specific directory.
- Added \`relative_files = true\` so paths in the report are relative to the repo root rather than absolute.

\`pyproject.toml\` new \`[tool.coverage.paths]\` block:
- Maps both \`pysrc/bytewax\` (editable install) and the various \`*/site-packages/bytewax\` patterns (wheel install) onto a single canonical path. The XML report uses the canonical (\`pysrc/bytewax/...\`) form, which Codecov can resolve against the repo tree.

## Verification

Before, \`coverage.xml\` had:
\`\`\`xml
<source>/run/host/var/home/ilias/Projects/bytewax/pysrc/bytewax</source>
<class name=\"dataflow.py\" filename=\"dataflow.py\" .../>
\`\`\`
Bare filenames + absolute source path — Codecov couldn't match the bare \`dataflow.py\` against any file in the repo tree.

After:
\`\`\`xml
<source></source>
<class name=\"dataflow.py\" filename=\"pysrc/bytewax/dataflow.py\" .../>
\`\`\`
Empty source + repo-relative filename — Codecov can resolve directly.

Local results unchanged: \`just test-py-cov\` shows 84% coverage (was 80% under the old config — the new config picks up some files the old directory-filter was missing, including \`_metrics.py\`).

## Side effect

The per-file lines in coverage reports will now show paths starting with \`pysrc/bytewax/\` instead of bare filenames. More verbose but disambiguates and matches the source tree.