### PR TITLE
test: cover run.py CLI/locator (50% → 95%) and operators.rs pure helpers

### DIFF
--- a/pytests/test_run.py
+++ b/pytests/test_run.py
@@ -1,0 +1,221 @@
+"""Tests for `bytewax.run` — particularly `_locate_dataflow`.
+
+The CLI-arg-parsing side of `run.py` is covered in `test_parse.py`. This
+module focuses on dynamically locating a `Dataflow` given a module name
+and an attribute or factory expression — the heart of
+`python -m bytewax.run <module:flow>`.
+"""
+
+import sys
+from types import ModuleType
+from typing import Iterator
+from unittest.mock import patch
+
+import pytest
+from bytewax.dataflow import Dataflow
+from bytewax.run import _locate_dataflow, _parse_args
+
+
+@pytest.fixture
+def stub_module() -> Iterator[str]:
+    """Register a synthetic module in `sys.modules` for the duration of
+    a test, exposing a variety of attributes that exercise every branch
+    in `_locate_dataflow`.
+    """
+    name = "_bytewax_test_locate_module"
+    mod = ModuleType(name)
+
+    # Variable case: a real Dataflow at module scope.
+    mod.flow = Dataflow("variable_case")  # type: ignore[attr-defined]
+
+    # Factory cases: functions that return a Dataflow.
+    def make_flow():
+        return Dataflow("no_args_factory")
+
+    def make_flow_with_args(name, value=42):
+        return Dataflow(f"{name}_{value}")
+
+    def make_flow_returns_int():
+        return 7  # not a Dataflow → triggers the RuntimeError branch
+
+    def make_flow_raises_typeerror():
+        # A genuine TypeError raised *inside* the factory body. Should
+        # propagate, not be swallowed by `_called_with_wrong_args`.
+        msg = "genuine error from inside factory"
+        raise TypeError(msg)
+
+    mod.make_flow = make_flow  # type: ignore[attr-defined]
+    mod.make_flow_with_args = make_flow_with_args  # type: ignore[attr-defined]
+    mod.make_flow_returns_int = make_flow_returns_int  # type: ignore[attr-defined]
+    mod.make_flow_raises_typeerror = make_flow_raises_typeerror  # type: ignore[attr-defined]
+
+    # Non-Dataflow attribute for the "wrong type" branch.
+    mod.not_a_flow = "this is a string"  # type: ignore[attr-defined]
+
+    sys.modules[name] = mod
+    try:
+        yield name
+    finally:
+        del sys.modules[name]
+
+
+# -----
+# `_locate_dataflow`: variable form (`module:flow_var`)
+# -----
+
+
+def test_locate_dataflow_returns_module_attribute(stub_module: str) -> None:
+    flow = _locate_dataflow(stub_module, "flow")
+    assert isinstance(flow, Dataflow)
+    assert flow.flow_id == "variable_case"
+
+
+def test_locate_dataflow_attribute_not_dataflow_raises(stub_module: str) -> None:
+    with pytest.raises(RuntimeError, match="valid Bytewax dataflow"):
+        _locate_dataflow(stub_module, "not_a_flow")
+
+
+def test_locate_dataflow_missing_attribute_raises(stub_module: str) -> None:
+    with pytest.raises(AttributeError, match="does_not_exist"):
+        _locate_dataflow(stub_module, "does_not_exist")
+
+
+# -----
+# `_locate_dataflow`: factory form (`module:make_flow(args)`)
+# -----
+
+
+def test_locate_dataflow_calls_factory_no_args(stub_module: str) -> None:
+    flow = _locate_dataflow(stub_module, "make_flow()")
+    assert isinstance(flow, Dataflow)
+    assert flow.flow_id == "no_args_factory"
+
+
+def test_locate_dataflow_calls_factory_with_positional_args(stub_module: str) -> None:
+    flow = _locate_dataflow(stub_module, "make_flow_with_args('hello')")
+    assert isinstance(flow, Dataflow)
+    assert flow.flow_id == "hello_42"
+
+
+def test_locate_dataflow_calls_factory_with_kwargs(stub_module: str) -> None:
+    flow = _locate_dataflow(stub_module, "make_flow_with_args('hi', value=99)")
+    assert flow.flow_id == "hi_99"
+
+
+def test_locate_dataflow_factory_returns_non_dataflow_raises(
+    stub_module: str,
+) -> None:
+    with pytest.raises(RuntimeError, match="valid Bytewax dataflow"):
+        _locate_dataflow(stub_module, "make_flow_returns_int()")
+
+
+def test_locate_dataflow_factory_called_with_wrong_args_raises(
+    stub_module: str,
+) -> None:
+    # `make_flow` takes no args; calling with one is wrong. The error
+    # surface should explain this came from arg-mismatch, not propagate
+    # a confusing internal TypeError.
+    with pytest.raises(TypeError, match="could not be called"):
+        _locate_dataflow(stub_module, "make_flow('unexpected')")
+
+
+def test_locate_dataflow_factory_internal_typeerror_propagates(
+    stub_module: str,
+) -> None:
+    # Distinct from "wrong args": the factory itself raises TypeError
+    # in its body. We must NOT mask this as an arg-mismatch error.
+    with pytest.raises(TypeError, match="genuine error from inside factory"):
+        _locate_dataflow(stub_module, "make_flow_raises_typeerror()")
+
+
+# -----
+# `_locate_dataflow`: malformed dataflow_name expressions
+# -----
+
+
+def test_locate_dataflow_syntax_error_in_expr(stub_module: str) -> None:
+    with pytest.raises(SyntaxError, match="attribute name or function call"):
+        _locate_dataflow(stub_module, "this is not valid python")
+
+
+def test_locate_dataflow_complex_callable_rejected(stub_module: str) -> None:
+    # `module:obj.method()` — the function ref is an Attribute, not a
+    # simple Name. Reject explicitly rather than try to resolve it.
+    with pytest.raises(TypeError, match="must be a simple name"):
+        _locate_dataflow(stub_module, "make_flow.weird()")
+
+
+def test_locate_dataflow_non_literal_args_rejected(stub_module: str) -> None:
+    # Args must be literal; references aren't allowed.
+    with pytest.raises(ValueError, match="literal values"):
+        _locate_dataflow(stub_module, "make_flow_with_args(some_variable)")
+
+
+def test_locate_dataflow_unsupported_expression_rejected(stub_module: str) -> None:
+    # Neither a Name nor a Call — this is an arithmetic expression.
+    with pytest.raises(ValueError, match="attribute name or function call"):
+        _locate_dataflow(stub_module, "1 + 1")
+
+
+# -----
+# `_locate_dataflow`: import-side errors
+# -----
+
+
+def test_locate_dataflow_module_does_not_exist_raises() -> None:
+    # The original ImportError propagates (its `.__traceback__` is
+    # non-None, which is the conditional re-raise in `_locate_dataflow`).
+    # The "Could not import" friendly-wrap branch is currently
+    # unreachable; treat as a separate cleanup task.
+    with pytest.raises(ImportError, match="definitely_not_a_real_module_xyz"):
+        _locate_dataflow("definitely_not_a_real_module_xyz", "flow")
+
+
+# -----
+# `_parse_args`: error paths not covered by `test_parse.py`
+# -----
+
+
+def test_parse_args_process_id_without_addresses_errors(monkeypatch) -> None:
+    """Passing -i without -a (and no BYTEWAX_HOSTFILE_PATH env var) is
+    a usage error: argparse should exit with code 2."""
+    # Ensure the helm-chart env vars don't accidentally satisfy the
+    # check.
+    for key in (
+        "BYTEWAX_HOSTFILE_PATH",
+        "BYTEWAX_POD_NAME",
+        "BYTEWAX_STATEFULSET_NAME",
+        "BYTEWAX_PROCESS_ID",
+        "BYTEWAX_ADDRESSES",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    with (
+        patch.object(sys, "argv", ["bytewax", "examples.basic:flow", "-i", "0"]),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        _parse_args()
+    # argparse `parser.error()` exits with code 2.
+    assert exc_info.value.code == 2
+
+
+def test_parse_args_recovery_dir_without_intervals_errors(monkeypatch) -> None:
+    """Setting --recovery-directory without --snapshot-interval and
+    --backup-interval should be flagged as a misconfig."""
+    for key in (
+        "BYTEWAX_RECOVERY_DIRECTORY",
+        "BYTEWAX_SNAPSHOT_INTERVAL",
+        "BYTEWAX_RECOVERY_BACKUP_INTERVAL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    with (
+        patch.object(
+            sys,
+            "argv",
+            ["bytewax", "examples.basic:flow", "--recovery-directory", "/tmp/r"],
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        _parse_args()
+    assert exc_info.value.code == 2

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -470,6 +470,7 @@ impl<'py> FromPyObject<'py> for StatefulBatchLogic {
     }
 }
 
+#[derive(Debug)]
 enum IsComplete {
     Retain,
     Discard,
@@ -1034,5 +1035,123 @@ where
         let downstream = kv_downstream.wrap_key();
 
         Ok((downstream, snaps))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the small pure-logic helpers in this module.
+    //!
+    //! The operator implementations themselves (`branch`, `flat_map_batch`,
+    //! `merge`, `stateful_batch`, etc.) extend Timely's `Stream` and need a
+    //! running Timely scope plus Python-wrapped values flowing through them
+    //! to exercise. Those code paths are covered by the Python integration
+    //! tests in `pytests/operators/`. Here we cover only the small helpers
+    //! that can be tested in isolation: Python ↔ Rust value extraction.
+    use super::*;
+    use pyo3::types::PyTuple;
+
+    /// Prepare a Python interpreter that can `import bytewax.errors`.
+    ///
+    /// Cargo runs tests in a Python that doesn't have bytewax installed,
+    /// but we need it for the error-path tests because `reraise_with`
+    /// resolves to a `BytewaxRuntimeError` declared in
+    /// `pysrc/bytewax/errors.py`. Prepending `pysrc/` to `sys.path` at
+    /// test time lets the lazy import succeed.
+    fn init_python_with_bytewax() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            py.run_bound("import sys; sys.path.insert(0, 'pysrc')", None, None)
+                .expect("could not extend sys.path with pysrc/");
+        });
+    }
+
+    #[test]
+    fn is_complete_true_means_discard() {
+        init_python_with_bytewax();
+        Python::with_gil(|py| {
+            let py_true: Py<PyAny> = true.into_py(py);
+            let result = IsComplete::extract_bound(py_true.bind(py)).unwrap();
+            assert!(matches!(result, IsComplete::Discard));
+        });
+    }
+
+    #[test]
+    fn is_complete_false_means_retain() {
+        init_python_with_bytewax();
+        Python::with_gil(|py| {
+            let py_false: Py<PyAny> = false.into_py(py);
+            let result = IsComplete::extract_bound(py_false.bind(py)).unwrap();
+            assert!(matches!(result, IsComplete::Retain));
+        });
+    }
+
+    #[test]
+    fn is_complete_non_bool_returns_descriptive_error() {
+        init_python_with_bytewax();
+        Python::with_gil(|py| {
+            let py_str: Py<PyAny> = "not a bool".into_py(py);
+            let err = IsComplete::extract_bound(py_str.bind(py))
+                .expect_err("string should not be coercible to bool");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("`is_complete` was not a `bool`"),
+                "error message should explain the field; got: {msg}",
+            );
+        });
+    }
+
+    #[test]
+    fn extract_ret_valid_emit_and_is_complete() {
+        init_python_with_bytewax();
+        Python::with_gil(|py| {
+            let emit_list: Py<PyAny> = vec!["a", "b", "c"].into_py(py);
+            let is_complete_obj: Py<PyAny> = false.into_py(py);
+            let tuple = PyTuple::new_bound(py, &[emit_list.bind(py), is_complete_obj.bind(py)]);
+            let (emit, is_complete) = StatefulBatchLogic::extract_ret(tuple.into_any()).unwrap();
+            assert_eq!(emit.len(), 3);
+            assert!(matches!(is_complete, IsComplete::Retain));
+        });
+    }
+
+    #[test]
+    fn extract_ret_non_tuple_input_errors() {
+        init_python_with_bytewax();
+        Python::with_gil(|py| {
+            let py_str: Py<PyAny> = "definitely not a tuple".into_py(py);
+            let result = StatefulBatchLogic::extract_ret(py_str.into_bound(py));
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn extract_ret_non_list_emit_errors_with_descriptive_message() {
+        init_python_with_bytewax();
+        Python::with_gil(|py| {
+            // A string is iterable but not a list — should fail with the
+            // explicit "was not a `list`" framing.
+            let bad_emit: Py<PyAny> = "scalar instead of list".into_py(py);
+            let is_complete_obj: Py<PyAny> = true.into_py(py);
+            let tuple = PyTuple::new_bound(py, &[bad_emit.bind(py), is_complete_obj.bind(py)]);
+            let err = StatefulBatchLogic::extract_ret(tuple.into_any())
+                .expect_err("string should not be coercible to Vec<PyObject>");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("`emit` was not a `list`"),
+                "error message should mention the offending field; got: {msg}",
+            );
+        });
+    }
+
+    #[test]
+    fn extract_ret_non_bool_is_complete_errors() {
+        init_python_with_bytewax();
+        Python::with_gil(|py| {
+            let emit_list: Py<PyAny> = Vec::<&str>::new().into_py(py);
+            let bad_is_complete: Py<PyAny> = "not a bool".into_py(py);
+            let tuple = PyTuple::new_bound(py, &[emit_list.bind(py), bad_is_complete.bind(py)]);
+            let result = StatefulBatchLogic::extract_ret(tuple.into_any());
+            assert!(result.is_err());
+        });
     }
 }


### PR DESCRIPTION
Closes the Tier 2 coverage gaps for `run.py` and `operators.rs` from the test-suite analysis.

## Tier 2 outcomes

| File | Before | After | Tests added |
|---|---|---|---|
| `pysrc/bytewax/run.py` | 50% | **95%** | 16 |
| `src/operators.rs` (Rust unit tests) | 0 tests | **7 tests** | 7 |
| Project total | 84% | **89%** | — |

## `pysrc/bytewax/run.py` (new file `pytests/test_run.py`)

The big gap was `_locate_dataflow` (~76 lines, fully untested). It dynamically resolves a `module:flow` or `module:factory(args)` string to a `Dataflow` instance — many branches, many failure modes. Added 14 tests via a session fixture (`stub_module`) that registers a synthetic module in `sys.modules` exposing every shape needed:

- Variable form (`module:flow`) — happy path; attribute exists but isn't a Dataflow; attribute doesn't exist.
- Factory form (`module:make_flow()`) — no args; positional args; kwargs; factory returns wrong type; factory called with wrong number of args; factory itself raises `TypeError` internally (must propagate, not be masked).
- Malformed `dataflow_name` — syntax errors; complex callable references like `obj.method()`; non-literal args; expressions that are neither Name nor Call.
- `__import__` failure for missing modules.

Plus 2 tests for `_parse_args` error paths that `test_parse.py` didn't reach: `-i` without `-a` (and no helm-chart env var); `--recovery-directory` without `--snapshot-interval`/`--backup-interval`. Both should `argparse.error()` with exit code 2.

### Discovery while testing

The `_locate_dataflow` "Could not import" friendly-message branch is currently unreachable: the conditional `if ex.__traceback__ is not None: raise` always re-raises the original `ImportError` (every raised exception has a non-None `__traceback__`). The test asserts the actual behavior (the original `ImportError` propagates) and notes this in a comment. Worth a separate cleanup PR but out of scope here.

## `src/operators.rs` (new `#[cfg(test)] mod tests` block)

The audit flagged this as the biggest untested Rust surface, but the framing was misleading: most of the file is operator traits over Timely streams (`branch`, `flat_map_batch`, `merge`, `stateful_batch`, etc.) which can't be unit-tested without a running Timely scope plus Python-wrapped values. Those code paths are exercised by the Python integration tests in `pytests/operators/`.

What *can* be unit-tested is the small Python ↔ Rust value extraction logic. Two helpers covered:

- `IsComplete::extract_bound` — `True` → `Discard`, `False` → `Retain`, non-bool → `BytewaxRuntimeError` with descriptive field name.
- `StatefulBatchLogic::extract_ret` — extracts the `(emit_list, is_complete)` tuple returned by user-side `StatefulBatchLogic.on_batch`. Tests cover: valid tuple, non-tuple input, non-list `emit`, non-bool `is_complete`. Each error path also asserts the descriptive message survives.

### Test setup helper

The error-path tests need `bytewax.errors.BytewaxRuntimeError` importable, but `cargo test` runs in a Python without bytewax installed. Added a small `init_python_with_bytewax()` helper that prepends `pysrc/` to `sys.path` after `prepare_freethreaded_python()`. Replaces the bare `pyo3::prepare_freethreaded_python()` call across all 7 tests in this module.

### Side change to `IsComplete`

Added `#[derive(Debug)]` so `.expect_err(...)` works in tests. Trivial; the variants weren't used in `Display` contexts elsewhere.

## What's deferred (Tier 3 and Tier 4)

The remaining items from the test-suite analysis are listed below. None of them belong in this PR — they involve design decisions or new disciplines, each deserving its own focused review surface. I'll file a tracking issue once this lands.

- **Tier 3:** add `hypothesis` for property-based testing of windowing/recovery; increase parametrize usage; fault-injection tests for recovery; full-pipeline integration tests.
- **Tier 4:** `pytest-xdist` for parallel execution; test markers (`@pytest.mark.slow`, `@pytest.mark.integration`); CONTRIBUTING.md testing-patterns section.

## Local validation

- `pytest pytests/test_run.py` — 16 passed
- `pytest --benchmark-skip pytests/` — 230 passed, 6 skipped (was 214/6)
- `cargo test --no-default-features` — 16 passed (was 9; +7 in `operators::tests`)
- `just lint` — exit 0
- `pytest --cov` — project total 89% (was 84%)