### PR TITLE
cleanup: remove deferred mypy overrides for kafka and stubgen, fix dead branch in run.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,22 +117,6 @@ ignore_missing_imports = true
 module = "docker.*"
 ignore_missing_imports = true
 
-# TODO: pre-existing type debt — `KafkaSourceMessage.topic` is `Optional[str]`
-# but `confluent-kafka>=2.14`'s stubs require non-None for `SerializationContext`.
-# Tighten the connector types (likely change `topic` to `str` and validate at
-# construction) and remove this override.
-[[tool.mypy.overrides]]
-module = "bytewax.connectors.kafka.*"
-ignore_errors = true
-
-# TODO: pre-existing type debt — newer typeshed's `ast` stubs are stricter
-# about list invariance (e.g. `list[Constant]` vs `list[expr]`). The fixes
-# are mechanical (`cast(...)` or restructuring builders). Build-time tool
-# only; not shipped.
-[[tool.mypy.overrides]]
-module = "stubgen"
-ignore_errors = true
-
 [[tool.mypy.overrides]]
 module = "jsonpickle.*"
 ignore_missing_imports = true

--- a/pysrc/bytewax/connectors/kafka/__init__.py
+++ b/pysrc/bytewax/connectors/kafka/__init__.py
@@ -57,11 +57,19 @@ K = TypeVar("K")
 V = TypeVar("V")
 """Type of value in a Kafka message."""
 
+# Covariant key/value type vars for `KafkaSinkMessage`. Sink messages are
+# `frozen=True` dataclasses so they're effectively read-only after
+# construction, which makes covariance the right semantic for callers
+# (e.g. a `KafkaSinkMessage[bytes, bytes]` should be assignable to a
+# `KafkaSinkMessage[Optional[bytes], Optional[bytes]]`). mypy still
+# warns about using a covariant TypeVar as a dataclass field type
+# because the generated `__init__` parameter is contravariant, hence
+# the per-line `# type: ignore[misc]` on the field declarations.
 K_co = TypeVar("K_co", covariant=True)
-"""Type of key in Kafka message."""
+"""Covariant type of key in a Kafka sink message."""
 
 V_co = TypeVar("V_co", covariant=True)
-"""Type of value in a Kafka message."""
+"""Covariant type of value in a Kafka sink message."""
 
 K2 = TypeVar("K2")
 """Type of key in a modified Kafka message."""
@@ -270,9 +278,19 @@ class _KafkaSourcePartition(
                     )
                     raise RuntimeError(err_msg)
 
-            headers = msg.headers()
-            if headers is None:
-                headers = []
+            # confluent_kafka 2.14+ types `headers()` as the union of
+            # list-of-tuples and dict, with `Optional[Union[str, bytes]]`
+            # values. At runtime we always get the list-of-tuples form
+            # with bytes values; normalize and skip any None values.
+            raw_headers = msg.headers() or []
+            raw_items: Iterable[Tuple[str, Optional[Union[str, bytes]]]] = (
+                raw_headers.items() if isinstance(raw_headers, dict) else raw_headers
+            )
+            headers: List[Tuple[str, bytes]] = [
+                (k, v if isinstance(v, bytes) else v.encode())
+                for k, v in raw_items
+                if v is not None
+            ]
             kafka_msg = KafkaSourceMessage(
                 key=msg.key(),
                 value=msg.value(),
@@ -376,7 +394,10 @@ class KafkaSource(
 
     def list_parts(self) -> List[str]:
         """Each Kafka partition is an input partition."""
-        config = {
+        # `AdminClient` accepts heterogeneous config values (str, int,
+        # float, bool); annotate the union explicitly so adding numeric
+        # entries via `update` doesn't violate the dict's invariance.
+        config: Dict[str, Union[str, int, float, bool]] = {
             "bootstrap.servers": ",".join(self._brokers),
         }
         config.update(self._add_config)
@@ -421,8 +442,8 @@ class KafkaSource(
 class KafkaSinkMessage(Generic[K_co, V_co]):
     """Message to be written to Kafka."""
 
-    key: K_co
-    value: V_co
+    key: K_co  # type: ignore[misc]
+    value: V_co  # type: ignore[misc]
 
     topic: Optional[str] = None
     headers: List[Tuple[str, bytes]] = field(default_factory=list)

--- a/pysrc/bytewax/connectors/kafka/operators.py
+++ b/pysrc/bytewax/connectors/kafka/operators.py
@@ -222,7 +222,10 @@ def deserialize_key(
     ) -> Union[KafkaSourceMessage[object, V], KafkaError[Optional[bytes], V]]:
         try:
             key = deserializer(
-                msg.key, SerializationContext(topic=msg.topic, field=MessageField.KEY)
+                msg.key,
+                SerializationContext(
+                    topic=cast(str, msg.topic), field=MessageField.KEY
+                ),
             )
             return msg._with_key(key)
         except Exception as e:
@@ -256,7 +259,8 @@ def deserialize_value(
     ) -> Union[KafkaSourceMessage[K, object], KafkaError[K, Optional[bytes]]]:
         try:
             value = deserializer(
-                msg.value, ctx=SerializationContext(msg.topic, MessageField.VALUE)
+                msg.value,
+                ctx=SerializationContext(cast(str, msg.topic), MessageField.VALUE),
             )
             return msg._with_value(value)
         except Exception as e:
@@ -306,7 +310,8 @@ def deserialize(
     ]:
         try:
             key = key_deserializer(
-                msg.key, ctx=SerializationContext(msg.topic, MessageField.KEY)
+                msg.key,
+                ctx=SerializationContext(cast(str, msg.topic), MessageField.KEY),
             )
         except Exception as e:
             err = ConfluentKafkaError(ConfluentKafkaError._KEY_DESERIALIZATION, f"{e}")
@@ -314,7 +319,8 @@ def deserialize(
 
         try:
             value = val_deserializer(
-                msg.value, ctx=SerializationContext(msg.topic, MessageField.VALUE)
+                msg.value,
+                ctx=SerializationContext(cast(str, msg.topic), MessageField.VALUE),
             )
         except Exception as e:
             err = ConfluentKafkaError(
@@ -351,7 +357,9 @@ def serialize_key(
     """
 
     def shim_mapper(msg: KafkaSinkMessage[Any, V]) -> KafkaSinkMessage[bytes, V]:
-        key = serializer(msg.key, ctx=SerializationContext(msg.topic, MessageField.KEY))
+        key = serializer(
+            msg.key, ctx=SerializationContext(cast(str, msg.topic), MessageField.KEY)
+        )
         assert key is not None
         return msg._with_key(key)
 
@@ -383,7 +391,8 @@ def serialize_value(
 
     def shim_mapper(msg: KafkaSinkMessage[K, Any]) -> KafkaSinkMessage[K, bytes]:
         value = serializer(
-            msg.value, ctx=SerializationContext(msg.topic, MessageField.VALUE)
+            msg.value,
+            ctx=SerializationContext(cast(str, msg.topic), MessageField.VALUE),
         )
         assert value is not None
         return msg._with_value(value)
@@ -422,11 +431,12 @@ def serialize(
         msg: KafkaSinkMessage[Any, Any],
     ) -> KafkaSinkMessage[bytes, bytes]:
         key = key_serializer(
-            msg.key, ctx=SerializationContext(msg.topic, MessageField.KEY)
+            msg.key, ctx=SerializationContext(cast(str, msg.topic), MessageField.KEY)
         )
         assert key is not None
         value = val_serializer(
-            msg.value, ctx=SerializationContext(msg.topic, MessageField.VALUE)
+            msg.value,
+            ctx=SerializationContext(cast(str, msg.topic), MessageField.VALUE),
         )
         assert value is not None
         return msg._with_key_and_value(key, value)

--- a/pysrc/bytewax/connectors/kafka/serde.py
+++ b/pysrc/bytewax/connectors/kafka/serde.py
@@ -41,6 +41,9 @@ class PlainAvroSerializer(Serializer):
             schema_str = schema.schema_str
         else:
             schema_str = schema
+        if schema_str is None:
+            msg = "schema must have a non-None string representation"
+            raise ValueError(msg)
         self.schema = parse_schema(json.loads(schema_str), named_schemas=named_schemas)
 
     # TODO: Re-enable once we get type hints for `confluent_kafka`.
@@ -87,6 +90,9 @@ class PlainAvroDeserializer(Deserializer):
             schema_str = schema.schema_str
         else:
             schema_str = schema
+        if schema_str is None:
+            msg = "schema must have a non-None string representation"
+            raise ValueError(msg)
         self.schema = parse_schema(json.loads(schema_str), named_schemas=named_schemas)
 
     # TODO: Re-enable once we get type hints for `confluent_kafka`.

--- a/pysrc/bytewax/run.py
+++ b/pysrc/bytewax/run.py
@@ -37,16 +37,16 @@ def _locate_dataflow(module_name, dataflow_name):
 
     This is adapted from Flask's codebase.
     """
-    try:
-        __import__(module_name)
-    except ImportError as ex:
-        # Reraise the ImportError if it occurred within the imported module.
-        # Determine this by checking whether the trace has a depth > 1.
-        if ex.__traceback__ is not None:
-            raise
-        else:
-            msg = f"Could not import {module_name!r}."
-            raise ImportError(msg) from None
+    # NB: a previous version of this function tried to wrap the
+    # `__import__` call in a try/except that would replace the
+    # ImportError with a friendlier "Could not import 'X'" message
+    # when only the top-level module name failed to resolve. The
+    # condition `if ex.__traceback__ is not None` it used to gate
+    # that wrap is always true on a raised exception, so the wrapping
+    # branch was unreachable and the original ImportError ("No module
+    # named 'X'") propagated regardless. Removed for clarity; the
+    # original ImportError is informative enough.
+    __import__(module_name)
 
     module = sys.modules[module_name]
 

--- a/pytests/test_run.py
+++ b/pytests/test_run.py
@@ -163,10 +163,6 @@ def test_locate_dataflow_unsupported_expression_rejected(stub_module: str) -> No
 
 
 def test_locate_dataflow_module_does_not_exist_raises() -> None:
-    # The original ImportError propagates (its `.__traceback__` is
-    # non-None, which is the conditional re-raise in `_locate_dataflow`).
-    # The "Could not import" friendly-wrap branch is currently
-    # unreachable; treat as a separate cleanup task.
     with pytest.raises(ImportError, match="definitely_not_a_real_module_xyz"):
         _locate_dataflow("definitely_not_a_real_module_xyz", "flow")
 

--- a/stubgen.py
+++ b/stubgen.py
@@ -78,11 +78,15 @@ def _sort_children(children: List[Tuple[_Meta, _N]]) -> List[_N]:
 
 
 def _stub_args(params: Mapping[str, Parameter]) -> ast.arguments:
-    posonly_args = []
-    args = []
-    defaults = []
-    kwonly_args = []
-    kwonly_defaults: List[Optional[ast.Constant]] = []
+    # Annotated as `ast.expr` (the abstract type ast.arguments expects)
+    # rather than the concrete `ast.Constant` mypy would otherwise
+    # infer, since `list[Constant]` is not assignable to `list[expr]`
+    # under Python's invariant list typing.
+    posonly_args: List[ast.arg] = []
+    args: List[ast.arg] = []
+    defaults: List[ast.expr] = []
+    kwonly_args: List[ast.arg] = []
+    kw_defaults: List[Optional[ast.expr]] = []
     vararg = None
     kwarg = None
     for pname, param in params.items():
@@ -102,9 +106,9 @@ def _stub_args(params: Mapping[str, Parameter]) -> ast.arguments:
         elif param.kind == Parameter.KEYWORD_ONLY:
             kwonly_args.append(ast.arg(arg=pname))
             if param.default is Parameter.empty:
-                kwonly_defaults.append(None)
+                kw_defaults.append(None)
             else:
-                kwonly_defaults.append(ast.Constant(param.default))
+                kw_defaults.append(ast.Constant(param.default))
 
         elif param.kind == Parameter.VAR_KEYWORD:
             kwarg = ast.arg(arg=pname)
@@ -117,7 +121,7 @@ def _stub_args(params: Mapping[str, Parameter]) -> ast.arguments:
         args,
         vararg,
         kwonly_args,
-        kwonly_defaults,
+        kw_defaults,
         kwarg,
         defaults,
     )
@@ -135,7 +139,9 @@ def _stub_func(
 ) -> Tuple[_Meta, ast.FunctionDef]:
     sig = inspect.signature(f)
 
-    body = []
+    # ast.FunctionDef expects body: list[stmt]; annotate explicitly so
+    # mypy doesn't infer list[Expr] (Expr <: stmt but list is invariant).
+    body: List[ast.stmt] = []
     docstring = inspect.getdoc(f)
     if docstring:
         body += [ast.Expr(ast.Constant(docstring, col_offset=ctx.col_offset))]
@@ -171,7 +177,7 @@ def _stub_init(
         + list(sig.parameters.items())
     )
 
-    body = [ast.Expr(ast.Constant(...))]
+    body: List[ast.stmt] = [ast.Expr(ast.Constant(...))]
 
     meta = _Meta(ctx.path, [])
     node = ast.FunctionDef(
@@ -205,7 +211,7 @@ def _stub_new(
     else:
         params = sig.parameters
 
-    body = []
+    body: List[ast.stmt] = []
     docstring = inspect.getdoc(f)
     if docstring:
         body += [ast.Expr(ast.Constant(docstring, col_offset=ctx.col_offset))]
@@ -238,19 +244,21 @@ CLS_IGNORE = [
 
 def _stub_cls(ctx: _Ctx, cls: type) -> Tuple[_Meta, ast.ClassDef]:
     deps = []
-    bases = []
+    # ClassDef expects bases: list[expr]; annotate explicitly so mypy
+    # doesn't infer list[Name] (Name <: expr but list is invariant).
+    bases: List[ast.expr] = []
     for base in cls.__bases__:
         if base is not object:
             bases.append(ast.Name(base.__qualname__))
             deps.append(base.__module__ + base.__qualname__)
 
-    body: List[ast.AST] = []
+    body: List[ast.stmt] = []
     docstring = inspect.getdoc(cls)
     if docstring:
         body += [ast.Expr(ast.Constant(docstring, col_offset=ctx.col_offset))]
     body += [ast.Expr(ast.Constant(...))]
 
-    children: List[Tuple[_Meta, ast.AST]] = []
+    children: List[Tuple[_Meta, ast.stmt]] = []
     if "__init__" not in cls.__dict__:
         # If there is no explicit `__init__`, try to derive it from
         # the class signature. The stub class's signature is derived
@@ -298,12 +306,12 @@ def _stub_getsetdescriptor(
         args=[ast.arg("self")],
         vararg=None,
         kwonlyargs=[],
-        kwonly_defaults=[],
+        kw_defaults=[],
         kwarg=None,
         defaults=[],
     )
 
-    body = []
+    body: List[ast.stmt] = []
     docstring = inspect.getdoc(gsd)
     if docstring:
         body += [ast.Expr(ast.Constant(docstring, col_offset=ctx.col_offset))]
@@ -323,24 +331,20 @@ def _stub_getsetdescriptor(
     return (meta, node)
 
 
-def _stub_val(ctx: _Ctx, obj: object) -> Tuple[_Meta, ast.Expr]:
+def _stub_val(ctx: _Ctx, obj: object) -> Tuple[_Meta, ast.AnnAssign]:
+    # `AnnAssign` is itself a stmt (e.g. `x: int = 5`). Returning it
+    # directly is correct; the previous version wrapped it in `ast.Expr`,
+    # which structurally requires an `expr` and fails type-checking.
     meta = _Meta(ctx.path, [])
-    body = ast.Expr(
-        ast.AnnAssign(
-            target=ast.Name(ctx.name()),
-            annotation=ast.Name("object"),
-            simple=1,
-        )
+    body = ast.AnnAssign(
+        target=ast.Name(ctx.name()),
+        annotation=ast.Name("object"),
+        simple=1,
     )
-
-    # docstring = inspect.getdoc(obj)
-    # if docstring:
-    #     body += [ast.Expr(ast.Constant(docstring, col_offset=ctx.col_offset))]
-
     return (meta, body)
 
 
-def _stub_obj(ctx: _Ctx, obj: object) -> Tuple[_Meta, ast.AST]:
+def _stub_obj(ctx: _Ctx, obj: object) -> Tuple[_Meta, ast.stmt]:
     if (
         inspect.isfunction(obj)
         or
@@ -377,12 +381,12 @@ MOD_IGNORE = [
 def _stub_mod(mod: ModuleType) -> ast.Module:
     ctx = _Ctx(mod.__name__)
 
-    body: List[ast.AST] = []
+    body: List[ast.stmt] = []
     docstring = inspect.getdoc(mod)
     if docstring:
         body += [ast.Expr(ast.Constant(docstring, col_offset=ctx.col_offset))]
 
-    children: List[Tuple[_Meta, ast.AST]] = [
+    children: List[Tuple[_Meta, ast.stmt]] = [
         _stub_obj(ctx.new_scope(n), obj)
         for n, obj in mod.__dict__.items()
         if n not in MOD_IGNORE
@@ -393,7 +397,7 @@ def _stub_mod(mod: ModuleType) -> ast.Module:
     # imported or functions have type hints that are imported.
     # Fortunately PyO3 doesn't support any of this yet so this won't
     # be needed.
-    imports: List[ast.Import] = []
+    imports: List[ast.stmt] = []
 
     return ast.Module(body=imports + body, type_ignores=[])
 


### PR DESCRIPTION
Close out two `[[tool.mypy.overrides]]` blocks added during the modernization arc as scoped TODO debt. Plus a small drive-by fix in `run.py`.

## Background

Two `ignore_errors = true` overrides have been suppressing mypy errors on `bytewax.connectors.kafka.*` and `stubgen` since the modernization PR. Both had explicit `# TODO` comments in `pyproject.toml`. This PR resolves the underlying type issues and removes both overrides.

## Changes

### `pysrc/bytewax/connectors/kafka/__init__.py`
- **Headers normalization**: `confluent-kafka>=2.14`'s stubs type `Message.headers()` as `dict | list of (str, Optional[Union[bytes, str]])`. Normalize at the construction site: filter `None` values, convert `dict` to list of tuples, encode `str` headers to `bytes`. The runtime is unchanged on real Kafka traffic (which always gives us `list[tuple[str, bytes]]`); the explicit normalization just makes it type-correct.
- **`AdminClient` config**: typed the local config dict as `Dict[str, Union[str, int, float, bool]]` to match the union AdminClient accepts. Strict typing of `dict` is invariant, so the previous bare `{"bootstrap.servers": "..."}` was inferred as `dict[str, str]` and rejected.
- **`KafkaSinkMessage` covariance**: kept the `K_co`/`V_co` covariant type vars so `KafkaSinkMessage[bytes, bytes]` remains assignable to `KafkaSinkMessage[Optional[bytes], Optional[bytes]]` (the operator signature). For frozen dataclasses this is the right semantic, but mypy still warns because the generated `__init__` parameter is contravariant. Used `# type: ignore[misc]` on the two field declarations rather than tightening to invariant — invariance broke real call patterns in `examples/redpanda_serde.py` and `examples/confluent_serde.py`.

### `pysrc/bytewax/connectors/kafka/operators.py`
- 8 `SerializationContext(...)` call sites changed `topic=msg.topic` → `topic=cast(str, msg.topic)`. `KafkaSourceMessage.topic` is `Optional[str]`; `SerializationContext` requires `str`. At runtime, messages received from Kafka always have a topic — the `Optional` is for in-test construction. Surgical `cast()` instead of tightening the public API.

### `pysrc/bytewax/connectors/kafka/serde.py`
- `parse_schema(json.loads(schema_str), ...)` now asserts `schema_str is not None` before the call. Previously `Schema.schema_str` could be `None` per the new stubs but we'd pass it directly to `json.loads` (which would crash at runtime with a less helpful message).

### `stubgen.py`
- **Real bug fixed**: `ast.arguments(...)` was being called with `kwonly_defaults=` — that kwarg doesn't exist; the actual name is `kw_defaults`. Python 3.13 silently accepts unknown kwargs with a `DeprecationWarning` (removal scheduled for 3.15). Renamed the keyword + the local variable.
- **List invariance**: ~9 sites where lists of concrete `ast` types (`Constant`, `Name`, `Expr`, `Import`) were passed to `ast` constructors expecting `list[expr]` / `list[stmt]`. Annotated the local variables as the abstract supertype (`List[ast.stmt]`, `List[ast.expr]`) so they're constructed with the right type from the start.
- **`_stub_val` return type**: was `Tuple[_Meta, ast.Expr]` wrapping `ast.AnnAssign(...)` in `ast.Expr(...)`, which is structurally wrong — `Expr` requires an `expr` and `AnnAssign` is a `stmt`. The `Expr` wrapper was redundant; the function now returns the `AnnAssign` directly with `Tuple[_Meta, ast.AnnAssign]`. Caller `_stub_obj` already accepted any `ast.AST`/`stmt`.
- Tightened `_stub_obj` return type from `ast.AST` to `ast.stmt` to match what every code path actually returns.

### `pysrc/bytewax/run.py` (drive-by)
- Removed the dead try/except wrapper in `_locate_dataflow` around `__import__(module_name)`. The conditional `if ex.__traceback__ is not None: raise` was always true (every raised exception has a non-None `__traceback__`), so the friendly-message branch was unreachable. Replaced with a comment explaining the history. The original `ImportError` ("No module named 'X'") propagates regardless — same behavior, less misleading code.

### `pyproject.toml`
- Removed both `[[tool.mypy.overrides]] ignore_errors = true` blocks that were scoping out the two areas above.

### `pytests/test_run.py` (drive-by)
- Removed the obsolete comment that referenced the now-deleted dead branch.

## Verification

- `just lint` exit 0 (mypy: `Success: no issues found in 23 source files` on bytewax + `Success: no issues found in 90 source files` on tests/docs/examples).
- `just test-py` 230 passed, 6 skipped (unchanged).
- `just test-rs` 16 passed.
- `just test-doc` 224 passed.

## What's deferred

PyO3 0.22 → 0.23+ migration is now tracked separately as **issue #17** (filed alongside this PR). That migration will surface its own set of type debt; this PR doesn't touch it.